### PR TITLE
Removing the override on urllib3.util.ssl_.DEFAULT_CIPHERS on MacOS.

### DIFF
--- a/playstore/playstore.py
+++ b/playstore/playstore.py
@@ -40,21 +40,11 @@ elif sys.version_info.major == 3 and (
             "ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20:ECDH+AESGCM:DH+AESGCM:"
             "ECDH+AES:DH+AES:RSA+AESGCM:RSA+AES:!DSS"
         )
-    elif platform.system() == "Darwin":
-        requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = (
-            "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+HIGH:"
-            "DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:RSA+3DES:!aNULL:!MD5"
-        )
 elif sys.version_info.major == 3 and sys.version_info.minor == 9:
     if platform.system() == "Windows":
         requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = (
             "ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20:ECDH+AESGCM:DH+AESGCM:"
             "ECDH+AES:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!eNULL:!MD5:!DSS"
-        )
-    elif platform.system() == "Darwin":
-        requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = (
-            "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+HIGH:"
-            "DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:RSA+3DES:!aNULL:!MD5"
         )
 else:
     raise RuntimeError("This version of Python is not supported yet")


### PR DESCRIPTION
Currently it just breaks the thing (tested on Python 3.8.6, urllib3==1.25.11)